### PR TITLE
feat: Add tool import functionality

### DIFF
--- a/app/api/import-tools/route.ts
+++ b/app/api/import-tools/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import { promises as fsPromises } from 'fs';
+
+export async function POST(request: NextRequest) {
+  try {
+    // Parse the request body
+    const importedTools = await request.json();
+    
+    // Validate the imported tools
+    if (!Array.isArray(importedTools)) {
+      return NextResponse.json(
+        { error: 'Invalid format: Imported data must be an array of tools' },
+        { status: 400 }
+      );
+    }
+    
+    // Validate each tool has required fields - only key is required
+    const validTools = importedTools.filter(tool => {
+      return tool.key;
+    });
+    
+    if (validTools.length === 0) {
+      return NextResponse.json(
+        { error: 'No valid tools found in the imported data. Each tool must have a key.' },
+        { status: 400 }
+      );
+    }
+    
+    // Read the current servers.json file
+    const serversFilePath = path.join(process.cwd(), 'public', 'servers.json');
+    const fileContent = await fsPromises.readFile(serversFilePath, 'utf8');
+    const currentServers = JSON.parse(fileContent);
+    
+    // Check for duplicate keys
+    const currentKeys = new Set(currentServers.map((server: any) => server.key));
+    const newTools = validTools.filter(tool => !currentKeys.has(tool.key));
+    const duplicateCount = validTools.length - newTools.length;
+    
+    // Merge the current servers with the new tools
+    const updatedServers = [...currentServers, ...newTools];
+    
+    // Write the updated servers back to the file
+    await fsPromises.writeFile(
+      serversFilePath,
+      JSON.stringify(updatedServers, null, 4),
+      'utf8'
+    );
+    
+    return NextResponse.json({
+      success: true,
+      message: `Successfully imported ${newTools.length} tools. ${duplicateCount} duplicates were skipped.`,
+      importedCount: newTools.length,
+      duplicateCount
+    });
+  } catch (error) {
+    console.error('Error importing tools:', error);
+    return NextResponse.json(
+      { error: 'Failed to import tools' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import Footer from '@/components/footer'
 import HeroText from '@/components/hero-text'
+import ImportToolForm from '@/components/import-tool-form'
 import SearchInput from '@/components/search-input'
 import allServers from '@/public/servers.json'
 import {useState, useMemo, useEffect, useCallback} from 'react'
@@ -92,6 +93,7 @@ export default function Home() {
                     </div>
                     <div className="flex gap-2">
                         <SearchInput onSearch={onSearch} />
+                        <ImportToolForm />
                     </div>
                 </div>
                 <div className="text-2xl font-bold">

--- a/components/import-tool-form.tsx
+++ b/components/import-tool-form.tsx
@@ -1,0 +1,189 @@
+'use client'
+import { useState } from 'react'
+
+interface ToolFormData {
+  name: string
+  key: string
+  description: string
+  homepage: string
+  env?: Record<string, string>
+}
+
+export default function ImportToolForm() {
+  const [isOpen, setIsOpen] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [formData, setFormData] = useState<ToolFormData>({
+    name: '',
+    key: '',
+    description: '',
+    homepage: '',
+  })
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }))
+  }
+
+  // Removed arg handling functions
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsSubmitting(true)
+    
+    try {
+      // Validate required fields
+      if (!formData.key) {
+        alert('Key is required')
+        setIsSubmitting(false)
+        return
+      }
+      
+      console.log('Submitting tool:', formData)
+      
+      // Call the API to add the tool
+      const response = await fetch('/api/import-tools', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify([formData]), // API expects an array of tools
+      })
+      
+      const data = await response.json()
+      
+      if (data.success) {
+        alert(`${data.message}\nReloading page to show updated tools...`)
+        // Reset form and close it
+        setFormData({
+          name: '',
+          key: '',
+          description: '',
+          homepage: '',
+        })
+        setIsOpen(false)
+        // Reload the page to show the updated tools
+        window.location.reload()
+      } else {
+        alert(`Error: ${data.error}`)
+      }
+    } catch (error) {
+      console.error('Error submitting tool:', error)
+      alert('Failed to import tool. See console for details.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors"
+      >
+        {isOpen ? 'Cancel' : 'Import Tool'}
+      </button>
+      
+      {isOpen && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white p-6 rounded-lg shadow-lg w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+            <div className="flex justify-between items-center mb-4">
+              <h2 className="text-xl font-bold">Import MCP Tool</h2>
+              <button 
+                onClick={() => setIsOpen(false)}
+                className="text-gray-500 hover:text-gray-700"
+              >
+                ✕
+              </button>
+            </div>
+            
+            <form onSubmit={handleSubmit}>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Name
+                  </label>
+                  <input
+                    type="text"
+                    name="name"
+                    value={formData.name}
+                    onChange={handleInputChange}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                    placeholder="Tool Name"
+                  />
+                </div>
+                
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Key <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    type="text"
+                    name="key"
+                    value={formData.key}
+                    onChange={handleInputChange}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                    placeholder="ToolKey"
+                    required
+                  />
+                </div>
+                
+                {/* Command field removed */}
+                
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Homepage
+                  </label>
+                  <input
+                    type="text"
+                    name="homepage"
+                    value={formData.homepage}
+                    onChange={handleInputChange}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                    placeholder="https://github.com/username/repo"
+                  />
+                </div>
+              </div>
+              
+              <div className="mb-4">
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Description
+                </label>
+                <textarea
+                  name="description"
+                  value={formData.description}
+                  onChange={handleInputChange}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                  rows={3}
+                  placeholder="Tool description"
+                />
+              </div>
+              
+              {/* Arguments section removed */}
+              
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={() => setIsOpen(false)}
+                  className="px-4 py-2 border border-gray-300 rounded hover:bg-gray-100"
+                  disabled={isSubmitting}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:opacity-75"
+                  disabled={isSubmitting}
+                >
+                  {isSubmitting ? 'Importing...' : 'Import Tool'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/server-content.tsx
+++ b/components/server-content.tsx
@@ -10,30 +10,148 @@ export default function ServerContent({ server }: { server: any }) {
 
     useEffect(() => {
         if (server?.homepage) {
-            // Extract owner and repo from GitHub URL
-            const match = server.homepage.match(/github\.com\/([^/]+)\/([^/]+)/)
-            if (match) {
-                const [, owner, repo] = match
-                // Fetch README content
-                fetch(`https://raw.githubusercontent.com/${owner}/${repo}/main/README.md`)
-                    .then(res => res.text())
+            console.log('Processing homepage URL:', server.homepage);
+            
+            // Check if the URL already points to a README file
+            if (server.homepage.toLowerCase().includes('readme.md')) {
+                console.log('URL already points to a README file');
+                // Convert GitHub web URL to raw content URL if needed
+                let readmeUrl = server.homepage;
+                if (readmeUrl.includes('github.com') && !readmeUrl.includes('raw.githubusercontent.com')) {
+                    readmeUrl = readmeUrl.replace('github.com', 'raw.githubusercontent.com')
+                                         .replace('/blob/', '/');
+                }
+                
+                console.log('Fetching from direct README URL:', readmeUrl);
+                fetch(readmeUrl)
+                    .then(res => {
+                        console.log('README direct fetch status:', res.status);
+                        return res.text();
+                    })
                     .then(text => {
-                        console.log('Fetched README content:', text.substring(0, 500) + '...');
+                        console.log('Fetched README content (direct):', text.substring(0, 200) + '...');
                         setReadme(text);
                     })
-                    .catch(() => {
-                        // Try README.md in different casing or try master branch
-                        fetch(`https://raw.githubusercontent.com/${owner}/${repo}/master/README.md`)
-                            .then(res => res.text())
-                            .then(text => {
-                                console.log('Fetched README content (master branch):', text.substring(0, 500) + '...');
-                                setReadme(text);
-                            })
-                            .catch(err => {
-                                console.error('Failed to fetch README:', err);
-                                setMarkdownError('Failed to fetch README content');
-                            })
+                    .catch(err => {
+                        console.error('Failed to fetch direct README:', err);
+                        setMarkdownError('Failed to fetch README content');
+                    });
+            } else if (server.homepage.includes('github.com') && server.homepage.includes('/tree/')) {
+                // Handle GitHub subdirectory URLs (e.g., /tree/main/src/puppeteer)
+                console.log('Detected GitHub subdirectory URL');
+                
+                // Transform /tree/ URL to /blob/ URL with README.md appended
+                const readmeUrl = server.homepage
+                    .replace('/tree/', '/blob/') // Change from tree to blob
+                    .replace(/\/$/, '') + '/README.md'; // Append README.md, handling trailing slash
+                
+                const rawUrl = readmeUrl
+                    .replace('github.com', 'raw.githubusercontent.com')
+                    .replace('/blob/', '/');
+                
+                console.log('Constructed README URL for subdirectory:', readmeUrl);
+                console.log('Raw URL for fetching:', rawUrl);
+                
+                fetch(rawUrl)
+                    .then(res => {
+                        console.log('Subdirectory README fetch status:', res.status);
+                        if (!res.ok) throw new Error(`Failed to fetch subdirectory README (status: ${res.status})`);
+                        return res.text();
                     })
+                    .then(text => {
+                        console.log('Fetched README content from subdirectory:', text.substring(0, 200) + '...');
+                        setReadme(text);
+                    })
+                    .catch(err => {
+                        console.error('Failed to fetch subdirectory README:', err);
+                        setMarkdownError('Failed to fetch README content from subdirectory');
+                    });
+            } else {
+                // Extract owner and repo from GitHub URL
+                const match = server.homepage.match(/github\.com\/([^/]+)\/([^/]+)/)
+                if (match) {
+                    const [, owner, repo] = match;
+                    console.log(`Extracted owner: ${owner}, repo: ${repo}`);
+                    
+                    // Construct URL with README.md appended
+                    const baseUrl = server.homepage.endsWith('/')
+                        ? server.homepage
+                        : `${server.homepage}/`;
+                    
+                    // Try to fetch README from the URL + README.md
+                    const readmeUrl = `${baseUrl}README.md`;
+                    const rawMainUrl = `https://raw.githubusercontent.com/${owner}/${repo}/main/README.md`;
+                    const rawMasterUrl = `https://raw.githubusercontent.com/${owner}/${repo}/master/README.md`;
+                    
+                    console.log('Trying to fetch README from:', readmeUrl);
+                    
+                    // First try with appended README.md
+                    fetch(readmeUrl.replace('github.com', 'raw.githubusercontent.com').replace('/blob/', '/'))
+                        .then(res => {
+                            console.log('README append fetch status:', res.status);
+                            if (!res.ok) throw new Error('Failed to fetch appended README');
+                            return res.text();
+                        })
+                        .then(text => {
+                            console.log('Fetched README content (appended):', text.substring(0, 200) + '...');
+                            setReadme(text);
+                        })
+                        .catch(() => {
+                            // Fall back to main branch
+                            console.log('Falling back to main branch README:', rawMainUrl);
+                            fetch(rawMainUrl)
+                                .then(res => {
+                                    console.log('README main branch fetch status:', res.status);
+                                    if (!res.ok) throw new Error('Failed to fetch main branch README');
+                                    return res.text();
+                                })
+                                .then(text => {
+                                    console.log('Fetched README content (main branch):', text.substring(0, 200) + '...');
+                                    setReadme(text);
+                                })
+                                .catch(() => {
+                                    // Try master branch as last resort
+                                    console.log('Falling back to master branch README:', rawMasterUrl);
+                                    fetch(rawMasterUrl)
+                                        .then(res => {
+                                            console.log('README master branch fetch status:', res.status);
+                                            if (!res.ok) throw new Error('Failed to fetch master branch README');
+                                            return res.text();
+                                        })
+                                        .then(text => {
+                                            console.log('Fetched README content (master branch):', text.substring(0, 200) + '...');
+                                            setReadme(text);
+                                        })
+                                        .catch(err => {
+                                            console.error('All README fetch attempts failed:', err);
+                                            setMarkdownError('Failed to fetch README content after multiple attempts');
+                                        });
+                                });
+                        });
+                } else {
+                    console.log('Not a GitHub URL or format not recognized');
+                    // For non-GitHub URLs, try appending README.md directly
+                    const baseUrl = server.homepage.endsWith('/')
+                        ? server.homepage
+                        : `${server.homepage}/`;
+                    const readmeUrl = `${baseUrl}README.md`;
+                    
+                    console.log('Trying to fetch README from non-GitHub URL:', readmeUrl);
+                    fetch(readmeUrl)
+                        .then(res => {
+                            console.log('Non-GitHub README fetch status:', res.status);
+                            if (!res.ok) throw new Error('Failed to fetch README');
+                            return res.text();
+                        })
+                        .then(text => {
+                            console.log('Fetched README from non-GitHub URL:', text.substring(0, 200) + '...');
+                            setReadme(text);
+                        })
+                        .catch(err => {
+                            console.error('Failed to fetch README from non-GitHub URL:', err);
+                            setMarkdownError('Failed to fetch README content');
+                        });
+                }
             }
         }
     }, [server])

--- a/public/servers.json
+++ b/public/servers.json
@@ -4,7 +4,9 @@
         "key": "AppleNotes",
         "command": "uvx",
         "description": "The server implements the ability to read and write to your Apple Notes. Require Python>=3.12.",
-        "args": ["apple-notes-mcp"],
+        "args": [
+            "apple-notes-mcp"
+        ],
         "homepage": "https://github.com/sirmews/apple-notes-mcp"
     },
     {
@@ -50,7 +52,10 @@
         "key": "firecrawl",
         "command": "npx",
         "description": "A MCP server implementation that integrates with Firecrawl for web scraping capabilities.",
-        "args": ["-y", "firecrawl-mcp"],
+        "args": [
+            "-y",
+            "firecrawl-mcp"
+        ],
         "env": {
             "FIRECRAWL_API_KEY": "{{apiKey@string::Get the api key from https://firecrawl.dev/}}"
         },
@@ -61,7 +66,9 @@
         "key": "HackerNews",
         "command": "uvx",
         "description": "The server provides tools for fetching information from Hacker News",
-        "args": ["mcp-hn"],
+        "args": [
+            "mcp-hn"
+        ],
         "homepage": "https://github.com/erithwik/mcp-hn"
     },
     {
@@ -69,14 +76,20 @@
         "key": "llmtxt",
         "command": "npx",
         "description": "A MCP server that extracts and serves context from llm.txt files, enabling AI models to understand file structure, dependencies, and code relationships in development environments.",
-        "args": ["-y", "@modelcontextprotocol/server-llm-txt"],
+        "args": [
+            "-y",
+            "@modelcontextprotocol/server-llm-txt"
+        ],
         "homepage": "https://github.com/mcp-get/community-servers/tree/main/src/server-llm-txt"
     },
     {
         "key": "Linear",
         "command": "npx",
         "description": "This server allowing LLMs to interact with Linear issues.",
-        "args": ["-y", "linear-mcp-server"],
+        "args": [
+            "-y",
+            "linear-mcp-server"
+        ],
         "env": {
             "LINEAR_API_KEY": "{{apiKey@string::Get the api key from linear.app}}"
         },
@@ -86,14 +99,20 @@
         "key": "MacOs",
         "command": "npx",
         "description": "A Model Context Protocol server that provides macOS-specific system information and operations.",
-        "args": ["-y", "@mcp-get-community/server-macos"],
+        "args": [
+            "-y",
+            "@mcp-get-community/server-macos"
+        ],
         "homepage": "https://mcp-get.com/packages/%40mcp-get-community%2Fserver-macos"
     },
     {
         "key": "MySQL",
         "command": "npx",
         "description": "An MCP server gives LLMs read - only access to MySQL databases for schema inspection and query execution.",
-        "args": ["-y", "@benborla29/mcp-server-mysql"],
+        "args": [
+            "-y",
+            "@benborla29/mcp-server-mysql"
+        ],
         "env": {
             "MYSQL_HOST": "{{host@string::database host}}",
             "MYSQL_PORT": "{{port@number::database port}}",
@@ -143,14 +162,20 @@
         "key": "SequentialThinking",
         "command": "npx",
         "description": "An MCP server tool for dynamic problem-solving with structured thinking.",
-        "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"],
+        "args": [
+            "-y",
+            "@modelcontextprotocol/server-sequential-thinking"
+        ],
         "homepage": "https://github.com/modelcontextprotocol/servers"
     },
     {
         "key": "Search1api",
         "command": "npx",
         "description": "A Model Context Protocol (MCP) server that provides search and crawl functionality using Search1API.",
-        "args": ["-y", "search1api-mcp"],
+        "args": [
+            "-y",
+            "search1api-mcp"
+        ],
         "env": {
             "SEARCH1API_KEY": "{{apiKey@string::Get the api key from www.search1api.com}}"
         },
@@ -160,14 +185,20 @@
         "key": "Shell",
         "command": "npx",
         "description": "A Node.js MCP implementation enables secure shell command execution for AI models.",
-        "args": ["-y", "mcp-shell"],
+        "args": [
+            "-y",
+            "mcp-shell"
+        ],
         "homepage": "https://github.com/hdresearch/mcp-shell"
     },
     {
         "key": "Slack",
         "command": "npx",
         "description": "MCP Server for the Slack API, enabling Claude to interact with Slack workspaces.",
-        "args": ["-y", "@modelcontextprotocol/server-slack"],
+        "args": [
+            "-y",
+            "@modelcontextprotocol/server-slack"
+        ],
         "env": {
             "SLACK_BOT_TOKEN": "{{botToken@string::Your slack bot token}}",
             "SLACK_TEAM_ID": "{{teamId@string::Your slack team id}}"
@@ -189,7 +220,10 @@
         "key": "Tavily",
         "command": "npx",
         "description": "Seamless interaction with the tavily-search and tavily-extract tools",
-        "args": ["-y", "tavily-mcp@0.1.2"],
+        "args": [
+            "-y",
+            "tavily-mcp@0.1.2"
+        ],
         "env": {
             "TAVILY_API_KEY": "{{apiKey@string::You can get the API key from https://tavily.com}}"
         },
@@ -209,7 +243,9 @@
         "key": "Timeplus",
         "command": "uvx",
         "description": "MCP Server for Timeplus, a SQL database to process millions of rows per second from Kafka, Pulsar, or ClickHouse.",
-        "args": ["mcp-timeplus"],
+        "args": [
+            "mcp-timeplus"
+        ],
         "env": {
             "TIMEPLUS_HOST": "{{host@string::database host, e.g. localhost}}",
             "TIMEPLUS_PORT": "{{port@number::database port, e.g. 8123}}",
@@ -222,7 +258,10 @@
         "key": "Twitter",
         "command": "npx",
         "description": "This MCP server allows Clients to interact with Twitter, enabling posting tweets and searching Twitter.",
-        "args": ["-y", "@enescinar/twitter-mcp"],
+        "args": [
+            "-y",
+            "@enescinar/twitter-mcp"
+        ],
         "env": {
             "API_KEY": "{{apiKey@string::You can get the API_KEY from https://developer.twitter.com/}}",
             "API_SECRET_KEY": "{{apiSecret@string::You can get the API_SECRET_KEY from https://developer.twitter.com/m}}",
@@ -235,7 +274,9 @@
         "key": "Web",
         "command": "uvx",
         "description": "A Model Context Protocol server that provides web content fetching capabilities",
-        "args": ["mcp-server-fetch"],
+        "args": [
+            "mcp-server-fetch"
+        ],
         "homepage": "https://pypi.org/project/mcp-server-fetch/"
     },
     {
@@ -243,7 +284,10 @@
         "key": "ZerolabEmail",
         "command": "uvx",
         "description": "MCP Server for Email fetching and sending. Use uvx mcp-email-server ui to get started",
-        "args": ["mcp-email-server@latest", "stdio"],
+        "args": [
+            "mcp-email-server@latest",
+            "stdio"
+        ],
         "homepage": "https://github.com/ai-zerolab/mcp-email-server"
     },
     {
@@ -251,10 +295,24 @@
         "key": "ZerolabToolbox",
         "command": "uvx",
         "description": "A set of tools to enhance LLM through MCP protocols. View our homepage for more information.",
-        "args": ["mcp-toolbox@latest", "stdio"],
+        "args": [
+            "mcp-toolbox@latest",
+            "stdio"
+        ],
         "env": {
             "FIGMA_API_KEY": "{{apiKey@string::Your figma api key}}"
         },
         "homepage": "https://github.com/ai-zerolab/mcp-toolbox"
+    },
+    {
+        "name": "puppeter",
+        "key": "puppeteer",
+        "command": "npx",
+        "description": "Web",
+        "args": [
+            "-y",
+            "@modelcontextprotocol/server-puppeteer"
+        ],
+        "homepage": "https://github.com/modelcontextprotocol/servers/tree/main/src/puppeteer"
     }
 ]


### PR DESCRIPTION
This commit introduces a new feature that allows users to import new tools into the application via a form.

Key changes:

-   Added a new component `ImportToolForm` to handle the tool import process.
-   Implemented an API endpoint `/api/import-tools` to receive and process the tool data.
-   The API validates the incoming data, checks for duplicate keys, and merges the new tools with the existing ones in `servers.json`.
-   The `servers.json` file is updated with the new tool information.
-   Added a button to the home page to trigger the import form.
-   Updated the server content component to handle different URL formats for fetching README files.